### PR TITLE
Implement test plan phase 1

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,10 @@ import docopt
 
 
 def pytest_collect_file(path, parent):
+    """Collect custom .docopt files compatible with multiple pytest versions."""
     if path.ext == ".docopt" and path.basename.startswith("test"):
+        if hasattr(DocoptTestFile, "from_parent"):
+            return DocoptTestFile.from_parent(parent, fspath=path)
         return DocoptTestFile(path, parent)
 
 
@@ -41,7 +44,13 @@ class DocoptTestFile(pytest.File):
         for name, doc, cases in parse_test(raw):
             name = self.fspath.purebasename
             for case in cases:
-                yield DocoptTestItem("%s(%d)" % (name, index), self, doc, case)
+                item_name = "%s(%d)" % (name, index)
+                if hasattr(DocoptTestItem, "from_parent"):
+                    yield DocoptTestItem.from_parent(
+                        self, name=item_name, doc=doc, case=case
+                    )
+                else:
+                    yield DocoptTestItem(item_name, self, doc, case)
                 index += 1
 
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,0 +1,7 @@
+"""Tests for positional argument parsing."""
+
+from docopt import Argument
+
+
+def test_argument_equality():
+    assert Argument('N') == Argument('N')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,8 @@
+"""Tests for command semantics."""
+
+from .util import run_docopt
+
+
+def test_basic_command():
+    usage = 'Usage: prog add'
+    assert run_docopt(usage, 'add') == {'add': True}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,10 @@
+"""Language and runtime error tests."""
+
+from pytest import raises
+from docopt import DocoptLanguageError
+
+
+def test_unmatched_parenthesis():
+    with raises(DocoptLanguageError):
+        from docopt import docopt
+        docopt('Usage: prog (', '')

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,0 +1,8 @@
+"""Tests for grouping constructs."""
+
+from docopt import Required, Optional, Argument
+
+
+def test_group_flatten():
+    group = Required(Optional(Argument('N')))
+    assert group.flat() == [Argument('N')]

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,9 @@
+"""Tests for short and long options handling."""
+
+from .util import run_docopt
+from docopt import Option
+
+
+def test_option_parse_simple():
+    assert Option.parse('-h') == Option('-h', None)
+    assert Option.parse('--help') == Option(None, '--help')

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,8 @@
+"""Low level parser component tests."""
+
+from docopt import parse_pattern, Tokens
+
+
+def test_parse_pattern_literal():
+    result = parse_pattern('N', Tokens('N'))
+    assert str(result) == "Required(Argument('N', None))"

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,8 @@
+"""Tests for [options] shortcut and -- handling."""
+
+from .util import run_docopt
+
+
+def test_options_shortcut():
+    usage = """Usage: prog [options]\nOptions: -h"""
+    assert run_docopt(usage, '') == {'-h': False}

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -1,0 +1,10 @@
+"""Stress tests for complex patterns."""
+
+from .util import run_docopt
+
+
+def test_many_arguments():
+    doc = 'Usage: prog ' + 'ARG ' * 20
+    argv = ' '.join('v{}'.format(i) for i in range(20))
+    result = run_docopt(doc, argv)
+    assert all(result['ARG'][i] == 'v{}'.format(i) for i in range(20))

--- a/tests/test_usage_sections.py
+++ b/tests/test_usage_sections.py
@@ -1,0 +1,8 @@
+"""Tests for Usage and Options sections parsing."""
+
+from docopt import parse_section
+
+
+def test_parse_section_usage():
+    text = '\nUsage: prog\n\nOptions:\n -h'
+    assert parse_section('usage:', text) == ['Usage: prog']

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,10 @@
+"""Utility helpers for Docopt tests."""
+
+from docopt import docopt
+
+
+def run_docopt(doc, argv='', **kwargs):
+    """Helper to run ``docopt`` with given argv string."""
+    if isinstance(argv, str):
+        argv = argv.split() if argv else []
+    return docopt(doc, argv=argv, **kwargs)


### PR DESCRIPTION
## Summary
- start reorganising tests under `tests/`
- add simple helpers in `tests/util.py`
- update `conftest.py` for multi-version pytest support
- begin migrating a few example tests into new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6844336ae2388326aa1c96ddad8caec7