### PR TITLE
Implement test plan phase 2

### DIFF
--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,7 +1,8 @@
 """Tests for positional argument parsing."""
 
-from docopt import Argument
+from docopt import Argument, docopt
 
 
 def test_argument_equality():
-    assert Argument('N') == Argument('N')
+    assert Argument("N") == Argument("N")
+

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,8 +1,19 @@
 """Tests for command semantics."""
 
 from .util import run_docopt
+import pytest
 
 
 def test_basic_command():
     usage = 'Usage: prog add'
     assert run_docopt(usage, 'add') == {'add': True}
+
+def test_commands_multi():
+    usage = 'Usage: prog (add|rm)'
+    assert run_docopt(usage, 'add') == {'add': True, 'rm': False}
+    assert run_docopt(usage, 'rm') == {'add': False, 'rm': True}
+    usage = 'Usage: prog a b'
+    assert run_docopt(usage, 'a b') == {'a': True, 'b': True}
+    with pytest.raises(SystemExit):
+        run_docopt('Usage: prog a b', 'b a')
+

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,3 +8,53 @@ def test_unmatched_parenthesis():
     with raises(DocoptLanguageError):
         from docopt import docopt
         docopt('Usage: prog (', '')
+
+from docopt import docopt, DocoptExit
+
+
+def test_long_options_error_handling():
+    with raises(DocoptExit):
+        docopt('Usage: prog', '--non-existent')
+    with raises(DocoptExit):
+        docopt('Usage: prog [--version --verbose]\n',
+               '--ver')
+    with raises(DocoptLanguageError):
+        docopt('Usage: prog --long\nOptions: --long ARG')
+    with raises(DocoptExit):
+        docopt('Usage: prog --long ARG\nOptions: --long ARG', '--long')
+    with raises(DocoptLanguageError):
+        docopt('Usage: prog --long=ARG\nOptions: --long')
+    with raises(DocoptExit):
+        docopt('Usage: prog --long\nOptions: --long', '--long=ARG')
+
+
+def test_short_options_error_handling():
+    with raises(DocoptLanguageError):
+        docopt('Usage: prog -x\nOptions: -x  this\n -x  that')
+    with raises(DocoptExit):
+        docopt('Usage: prog', '-x')
+    with raises(DocoptLanguageError):
+        docopt('Usage: prog -o\nOptions: -o ARG')
+    with raises(DocoptExit):
+        docopt('Usage: prog -o ARG\nOptions: -o ARG', '-o')
+
+
+def test_language_errors():
+    with raises(DocoptLanguageError):
+        docopt('no usage with colon here')
+    with raises(DocoptLanguageError):
+        docopt('usage: here \n\n and again usage: here')
+
+
+def test_issue_40():
+    with raises(SystemExit):
+        docopt('usage: prog --help-commands | --help', '--help')
+    assert docopt('usage: prog --aabb | --aa', '--aa') == {'--aabb': False, '--aa': True}
+
+
+def test_issue_71_double_dash_is_not_a_valid_option_argument():
+    with raises(DocoptExit):
+        docopt('usage: prog [--log=LEVEL] [--] <args>...', '--log -- 1 2')
+    with raises(DocoptExit):
+        docopt('usage: prog [-l LEVEL] [--] <args>...\noptions: -l LEVEL', '-l -- 1 2')
+

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,8 +1,22 @@
 """Tests for grouping constructs."""
 
 from docopt import Required, Optional, Argument
+from docopt import Option, Either, OneOrMore, Command
 
 
 def test_group_flatten():
     group = Required(Optional(Argument('N')))
     assert group.flat() == [Argument('N')]
+
+
+def test_optional_required_either():
+    assert Optional(Option('-a')).match([Option('-a')]) == (True, [], [Option('-a')])
+    assert Required(Option('-a')).match([]) == (False, [], [])
+    assert Either(Option('-a'), Option('-b')).match([Option('-a')]) == (True, [], [Option('-a')])
+
+
+def test_one_or_more_and_list_arguments():
+    assert OneOrMore(Argument('N')).match([Argument(None, 9)]) == (True, [], [Argument('N', 9)])
+    assert Required(Argument('N'), Argument('N')).fix().match([
+        Argument(None, '1'), Argument(None, '2')]) == (True, [], [Argument('N', ['1', '2'])])
+

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -2,8 +2,50 @@
 
 from .util import run_docopt
 from docopt import Option
+import pytest
 
 
 def test_option_parse_simple():
     assert Option.parse('-h') == Option('-h', None)
     assert Option.parse('--help') == Option(None, '--help')
+
+
+def test_option_parsing_extended():
+    assert Option.parse('-h --help') == Option('-h', '--help')
+    assert Option.parse('-h, --help') == Option('-h', '--help')
+    assert Option.parse('-h TOPIC') == Option('-h', None, 1)
+    assert Option.parse('--help TOPIC') == Option(None, '--help', 1)
+    assert Option.parse('-h TOPIC --help TOPIC') == Option('-h', '--help', 1)
+    assert Option.parse('-h TOPIC, --help TOPIC') == Option('-h', '--help', 1)
+    assert Option.parse('-h TOPIC, --help=TOPIC') == Option('-h', '--help', 1)
+    assert Option.parse('-h  Description...') == Option('-h', None)
+    assert Option.parse('-h --help  Description...') == Option('-h', '--help')
+    assert Option.parse('-h TOPIC  Description...') == Option('-h', None, 1)
+    assert Option.parse('    -h') == Option('-h', None)
+    assert Option.parse('-h TOPIC  Descripton... [default: 2]') == \
+        Option('-h', None, 1, '2')
+    assert Option.parse('-h TOPIC  Descripton... [default: topic-1]') == \
+        Option('-h', None, 1, 'topic-1')
+    assert Option.parse('--help=TOPIC  ... [default: 3.14]') == \
+        Option(None, '--help', 1, '3.14')
+    assert Option.parse('-h, --help=DIR  ... [default: ./]') == \
+        Option('-h', '--help', 1, './')
+    assert Option.parse('-h TOPIC  Descripton... [dEfAuLt: 2]') == \
+        Option('-h', None, 1, '2')
+
+def test_option_name():
+    assert Option('-h', None).name == '-h'
+    assert Option('-h', '--help').name == '--help'
+    assert Option(None, '--help').name == '--help'
+
+def test_count_multiple_flags():
+    assert run_docopt('usage: prog [-v]', '-v') == {'-v': True}
+    assert run_docopt('usage: prog [-vv]', '') == {'-v': 0}
+    assert run_docopt('usage: prog [-vv]', '-v') == {'-v': 1}
+    assert run_docopt('usage: prog [-vv]', '-vv') == {'-v': 2}
+    with pytest.raises(SystemExit):
+        run_docopt('usage: prog [-vv]', '-vvv')
+    assert run_docopt('usage: prog [-v | -vv | -vvv]', '-vvv') == {'-v': 3}
+    assert run_docopt('usage: prog -v...', '-vvvvvv') == {'-v': 6}
+    assert run_docopt('usage: prog [--ver --ver]', '--ver --ver') == {'--ver': 2}
+

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,8 +1,33 @@
 """Low level parser component tests."""
 
+from docopt import DocoptExit
+from docopt import parse_argv, Option, Argument, Command, OptionsShortcut, Required, Optional, Either, OneOrMore
 from docopt import parse_pattern, Tokens
 
 
 def test_parse_pattern_literal():
     result = parse_pattern('N', Tokens('N'))
     assert str(result) == "Required(Argument('N', None))"
+
+
+def test_parse_argv_complex():
+    o = [Option('-h'), Option('-v', '--verbose'), Option('-f', '--file', 1)]
+    TS = lambda s: Tokens(s, error=DocoptExit)
+    assert parse_argv(TS(''), options=o) == []
+    assert parse_argv(TS('-h'), options=o) == [Option('-h', None, 0, True)]
+    assert parse_argv(TS('-h --verbose'), options=o) == [
+        Option('-h', None, 0, True), Option('-v', '--verbose', 0, True)
+    ]
+    assert parse_argv(TS('-h --file f.txt'), options=o) == [
+        Option('-h', None, 0, True), Option('-f', '--file', 1, 'f.txt')
+    ]
+
+
+def test_parse_pattern_options():
+    o = [Option('-h'), Option('-v', '--verbose'), Option('-f', '--file', 1)]
+    assert parse_pattern('[ -h ]', options=o) == Required(Optional(Option('-h')))
+    assert parse_pattern('[ ARG ... ]', options=o) == Required(
+        Optional(OneOrMore(Argument('ARG')))
+    )
+    assert parse_pattern('[options]', options=o) == Required(Optional(OptionsShortcut()))
+

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -6,3 +6,12 @@ from .util import run_docopt
 def test_options_shortcut():
     usage = """Usage: prog [options]\nOptions: -h"""
     assert run_docopt(usage, '') == {'-h': False}
+
+
+def test_issue_68_options_shortcut_does_not_include_options_in_usage_pattern():
+    args = run_docopt('usage: prog [-ab] [options]\noptions: -x\n -y', '-ax')
+    assert args['-a'] is True
+    assert args['-b'] is False
+    assert args['-x'] is True
+    assert args['-y'] is False
+

--- a/tests/test_usage_sections.py
+++ b/tests/test_usage_sections.py
@@ -6,3 +6,44 @@ from docopt import parse_section
 def test_parse_section_usage():
     text = '\nUsage: prog\n\nOptions:\n -h'
     assert parse_section('usage:', text) == ['Usage: prog']
+
+
+def test_parse_section_complex():
+    usage = '''usage: this
+
+usage:hai
+usage: this that
+
+usage: foo
+       bar
+
+PROGRAM USAGE:
+ foo
+ bar
+usage:
+\ttoo
+\ttar
+Usage: eggs spam
+BAZZ
+usage: pit stop'''
+    assert parse_section('usage:', 'foo bar fizz buzz') == []
+    assert parse_section('usage:', 'usage: prog') == ['usage: prog']
+    assert parse_section('usage:', 'usage: -x\n -y') == ['usage: -x\n -y']
+    assert parse_section('usage:', usage) == [
+        'usage: this',
+        'usage:hai',
+        'usage: this that',
+        'usage: foo\n       bar',
+        'PROGRAM USAGE:\n foo\n bar',
+        'usage:\n\ttoo\n\ttar',
+        'Usage: eggs spam',
+        'usage: pit stop',
+    ]
+
+from docopt import parse_defaults, Option
+
+
+def test_issue_126_defaults_not_parsed_correctly_when_tabs():
+    section = 'Options:\n\t--foo=<arg>  [default: bar]'
+    assert parse_defaults(section) == [Option(None, '--foo', 1, 'bar')]
+


### PR DESCRIPTION
## Summary
- port initial tests from `test_docopt.py` into modular test files
- extend coverage of options, commands, parsing utilities and error handling
- add complex usage section parsing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68443ce84dcc83269124bb1e1809af89