### PR TITLE
Implement test plan phase 3

### DIFF
--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,8 +1,22 @@
 """Tests for positional argument parsing."""
 
 from docopt import Argument, docopt
+import pytest
 
 
 def test_argument_equality():
     assert Argument("N") == Argument("N")
+
+
+def test_repeated_arguments():
+    usage = "Usage: prog NAME..."
+    assert docopt(usage, "alice bob") == {"NAME": ["alice", "bob"]}
+    with pytest.raises(SystemExit):
+        docopt(usage, "")
+
+
+def test_optional_argument_list():
+    usage = "Usage: prog [NAME ...]"
+    assert docopt(usage, "alice bob") == {"NAME": ["alice", "bob"]}
+    assert docopt(usage, "") == {"NAME": []}
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,3 +17,10 @@ def test_commands_multi():
     with pytest.raises(SystemExit):
         run_docopt('Usage: prog a b', 'b a')
 
+
+def test_repeated_commands():
+    usage = 'Usage: prog go...'
+    assert run_docopt(usage, 'go go go') == {'go': 3}
+    with pytest.raises(SystemExit):
+        run_docopt(usage, '')
+

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -49,3 +49,14 @@ def test_count_multiple_flags():
     assert run_docopt('usage: prog -v...', '-vvvvvv') == {'-v': 6}
     assert run_docopt('usage: prog [--ver --ver]', '--ver --ver') == {'--ver': 2}
 
+
+def test_option_defaults_and_repeats():
+    doc = """Usage: prog [--path=<p>...]
+Options:
+    --path=<p>  Path [default: a b]
+"""
+    result = run_docopt(doc, '')
+    assert result == {'--path': ['a', 'b']}
+    result = run_docopt(doc, '--path=c --path=d')
+    assert result == {'--path': ['c', 'd']}
+

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,6 +1,7 @@
 """Tests for [options] shortcut and -- handling."""
 
 from .util import run_docopt
+import pytest
 
 
 def test_options_shortcut():
@@ -14,4 +15,11 @@ def test_issue_68_options_shortcut_does_not_include_options_in_usage_pattern():
     assert args['-b'] is False
     assert args['-x'] is True
     assert args['-y'] is False
+
+
+def test_double_dash_stops_option_parsing():
+    usage = 'Usage: prog [-o] [--] <arg>\nOptions: -o'
+    assert run_docopt(usage, '-- -v') == {'-o': False, '<arg>': '-v', '--': True}
+    with pytest.raises(SystemExit):
+        run_docopt('Usage: prog [-o] <arg>\nOptions: -o', '-- -v')
 


### PR DESCRIPTION
## Summary
- expand arguments tests with repeated and optional lists
- verify command repetition accumulation
- add double-dash handling test for option parsing
- test repeated option defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684443e3b66083268c6aa655bfcda012