### PR TITLE
Implement Test Plan Phase 4

### DIFF
--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -8,3 +8,26 @@ def test_many_arguments():
     argv = ' '.join('v{}'.format(i) for i in range(20))
     result = run_docopt(doc, argv)
     assert all(result['ARG'][i] == 'v{}'.format(i) for i in range(20))
+
+
+def test_many_options():
+    count = 30
+    usage = 'Usage: prog ' + ' '.join('[--opt{0}=<v{0}>]'.format(i) for i in range(count))
+    options = '\n'.join('  --opt{0}=<v{0}>'.format(i) for i in range(count))
+    doc = usage + '\n\nOptions:\n' + options
+    argv = ' '.join('--opt{0}=val{0}'.format(i) for i in range(count))
+    result = run_docopt(doc, argv)
+    expected = {'--opt{0}'.format(i): 'val{0}'.format(i) for i in range(count)}
+    assert result == expected
+
+
+def test_nested_either_chain():
+    depth = 10
+    expr = 'cmd0'
+    for i in range(1, depth):
+        expr = 'cmd{0} | ({1})'.format(i, expr)
+    doc = 'Usage: prog ' + expr
+    argv = 'cmd{}'.format(depth - 1)
+    result = run_docopt(doc, argv)
+    for i in range(depth):
+        assert result['cmd{}'.format(i)] == (i == depth - 1)


### PR DESCRIPTION
## Summary
- add stress tests for long option lists and nested command chains
- fix Python 3.2 compatibility in stress tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6844465c073883268edf1f461450c42b