### PR TITLE
Add Python 3.2 env to tox and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 python:
   - "2.7"
+  - "3.2"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Use `pip <http://pip-installer.org>`_ or easy_install::
 Alternatively, you can just drop ``docopt.py`` file into your
 project--it is self-contained.
 
-**docopt** is tested with Python 2.7, 3.4, 3.5, and 3.6.
+**docopt** is tested with Python 2.7, 3.2, 3.4, 3.5, and 3.6.
 
 Testing
 ======================================================================

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py32, py34, py35, py36
+skip_missing_interpreters = True
 
 [testenv]
 commands = py.test


### PR DESCRIPTION
## Summary
- update tox to include py32 and allow missing interpreters
- run CI tests under Python 3.2
- mention Python 3.2 in README and classifiers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68444660f4e883269c2abe044ca909d3