### PR TITLE
Implement porting plan phase2

### DIFF
--- a/Porting-Plan.md
+++ b/Porting-Plan.md
@@ -37,6 +37,13 @@ from __future__ import with_statement
 4. Add small compatibility modules for any missing standard‑library
    functionality.
 
+### Results
+
+* Reviewed `docopt.py` and the test suite; no features newer than Python
+  3.2 were found.
+* Removed the obsolete `with_statement` import from `test_docopt.py`.
+* All tests continue to pass under the default Python 3.12 interpreter.
+
 ## Phase 3 – Packaging Adjustments
 
 1. Update `setup.py` to state the supported Python version using

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from docopt import (docopt, DocoptExit, DocoptLanguageError,
                     Option, Argument, Command, OptionsShortcut,
                     Required, Optional, Either, OneOrMore,


### PR DESCRIPTION
## Summary
- drop legacy future import in tests
- document compatibility review and removal of the with_statement import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6844514a8c408326b7040686aa7bec15