### PR TITLE
Implement Porting Plan Phase 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,17 +33,12 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Topic :: Utilities',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',
     ],
+    python_requires='>=3.2,<3.3',
     tests_require=[
-            'pytest',
+            'pytest<3',
         ],
     cmdclass={
             'test': PyTestCommand,

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,10 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py32, py34, py35, py36
+envlist = py32
 skip_missing_interpreters = True
 
 [testenv]
 commands = pytest
-deps = pytest
+deps = pytest<3
 
-[testenv:py27]
-commands =
-    pytest
-    pytest --doctest-modules docopt.py
-deps = pytest


### PR DESCRIPTION
## Summary
- adjust `setup.py` packaging metadata for Python 3.2 only
- narrow tox env to py32 and pin pytest for Python 3.2 compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684451c3941083268f5958cefa28f23c