### PR TITLE
Implement Porting Plan Phase 4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Use `pip <http://pip-installer.org>`_ or easy_install::
 Alternatively, you can just drop ``docopt.py`` file into your
 project--it is self-contained.
 
-**docopt** is tested with Python 2.7, 3.2, 3.4, 3.5, and 3.6.
+**docopt** is tested with Python 2.7, 3.2.5, 3.4, 3.5, and 3.6.
 
 Testing
 ======================================================================

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from docopt import (docopt, DocoptExit, DocoptLanguageError,
                     Option, Argument, Command, OptionsShortcut,
                     Required, Optional, Either, OneOrMore,


### PR DESCRIPTION
## Summary
- make test suite compatible with Python 3.2 by dropping deprecated `__future__` import
- mention Python 3.2.5 directly in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684451dc9e048326812127390146e76e